### PR TITLE
Move ViewPropTypes to deprecated package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
-import {
-  requireNativeComponent,
-  ViewPropTypes
-} from 'react-native';
+import { requireNativeComponent } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import { bool, string, number, array, shape, arrayOf } from 'prop-types';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "description": "A <ImageSequence> component for react-native",
   "peerDependencies": {
     "react-native": ">=0.47.0",
-    "prop-types": ">=15.5.0"
+    "prop-types": ">=15.5.0",
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "license": "MIT",
   "homepage": "https://github.com/bwindsor/react-native-image-sequence",


### PR DESCRIPTION
Without these changes, the project is not usable on newer versions of React, since `ViewPropTypes` are being moved out of React Native.

See https://github.com/facebook/react-native/issues/33557 for more info.